### PR TITLE
feat: 기본 레이아웃 구조 및 글로벌 스타일 설정

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,4 +1,4 @@
-@import url('https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css');
+@import url("https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css");
 
 * {
   box-sizing: border-box;
@@ -8,8 +8,9 @@ html,
 body {
   margin: 0;
   padding: 0;
-  background-color: #fefefe;
-  font-family: 'Pretendard', -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+  background: linear-gradient(90deg, #eff6ff 0%, #eef2ff 50%, #faf5ff 100%);
+  font-family: "Pretendard", -apple-system, BlinkMacSystemFont, system-ui,
+    sans-serif;
   color: #222;
 }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,6 +3,7 @@
 * {
   box-sizing: border-box;
 }
+
 html,
 body {
   margin: 0;
@@ -10,4 +11,10 @@ body {
   background-color: #fefefe;
   font-family: 'Pretendard', -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
   color: #222;
+}
+
+a {
+  color: black;
+  text-decoration: none;
+  cursor: pointer;
 }

--- a/src/app/layout.module.css
+++ b/src/app/layout.module.css
@@ -1,0 +1,21 @@
+.container {
+  display: flex;
+  flex-direction: column; 
+  max-width: 600px;
+  min-height: 100vh;
+  margin: 0 auto;
+  border: 1px solid red;
+  padding: 0px 15px;
+}
+
+.container > main {
+  flex: 1;
+  justify-items: center;
+  padding-top: 30px;
+}
+
+.container > footer {
+  padding: 100px 0px;
+  text-align: center;
+  color: gray;
+}

--- a/src/app/layout.module.css
+++ b/src/app/layout.module.css
@@ -1,7 +1,7 @@
 .container {
   display: flex;
   flex-direction: column; 
-  max-width: 600px;
+  max-width: 700px;
   min-height: 100vh;
   margin: 0 auto;
   border: 1px solid red;

--- a/src/app/layout.module.css
+++ b/src/app/layout.module.css
@@ -15,7 +15,8 @@
 }
 
 .container > footer {
-  padding: 100px 0px;
+  padding: 50px 0px;
+  font-size: small;
   text-align: center;
   color: gray;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import "./globals.css";
 import StyledComponentsRegistry from "@/lib/registry";
+import style from "./layout.module.css";
 import Header from "@/components/Header";
 
 export const metadata: Metadata = {
@@ -18,8 +19,12 @@ export default function RootLayout({
       <body>
         <StyledComponentsRegistry>
           <Header />
-          <main>{children}</main>
-          <footer>© 2025 MiniTax. 프리랜서를 위한 스마트한 세금 계산기</footer>
+          <div className={style.container}>
+            <main>{children}</main>
+            <footer>
+              © 2025 MiniTax. 프리랜서를 위한 스마트한 세금 계산기
+            </footer>
+          </div>
         </StyledComponentsRegistry>
       </body>
     </html>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,11 +1,32 @@
 "use client";
 
 import Link from "next/link";
+import styled from "styled-components";
+
+const HeaderWrapper = styled.header`
+  display: flex;
+  align-items: center;
+  height: 60px;
+  padding: 0 2rem;
+  background-color: #fff;
+  border-bottom: 1px solid #eaeaea;
+`;
+
+const Logo = styled(Link)`
+  font-size: 1.2rem;
+  font-weight: 600;
+  color: #111;
+  text-decoration: none;
+
+  &:hover {
+    color: #2563eb;
+  }
+`;
 
 export default function Header() {
   return (
-    <header>
-      <Link href="/">MiniTax</Link>
-    </header>
+    <HeaderWrapper>
+      <Logo href="/">MiniTax</Logo>
+    </HeaderWrapper>
   );
 }


### PR DESCRIPTION
### 주요 변경 사항
- layout.tsx에 공통 레이아웃 구조 설정 (Header, main, footer)
- styled-components 기반 Header 컴포넌트 스타일 적용 및 container 외부로 분리
- globals.css에 Pretendard 폰트 및 글로벌 a 태그 스타일 추가 (색상, 커서 포인터 등)
- .container에 레이아웃 스타일 적용 (flex, max-width: 700px, padding 등)
- footer 스타일 조정 (여백, 폰트 크기, 색상 등)
- 글로벌 배경에 Linear Gradient 그라디언트 적용

### 스타일 구성 요약
- 하이브리드 스타일링: Header → styled-components / layout, footer → CSS Module
- 반응형 구조 및 콘텐츠 중앙 정렬 고려 (max-width, margin: auto)
- min-height: 100vh + flex-direction: column 조합으로 Footer 하단 고정 처리
