### PR TITLE
feat: 메인 페이지 UI 구성 및 Header 스타일 개선

### DIFF
--- a/src/app/layout.module.css
+++ b/src/app/layout.module.css
@@ -2,8 +2,7 @@
   max-width: 1000px;
   min-height: 100vh;
   margin: 0 auto;
-  border: 1px solid red;
-  padding: 0px 15px;
+  padding: 60px 15px 0;
 }
 
 .container > main {

--- a/src/app/page.module.css
+++ b/src/app/page.module.css
@@ -1,0 +1,128 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  margin: 0 auto;
+  padding-bottom: 2rem;
+}
+
+.headerSection h1 {
+  font-size: 5rem;
+  font-weight: 600;
+  color: #1f2937;
+  margin: 1rem;
+  padding-bottom: 1rem;
+}
+
+.divider {
+  width: 5.8rem;
+  height: 4px;
+  background: linear-gradient(to right, #3b82f6, #8b5cf6);
+  margin: 0 auto 2rem;
+  border-radius: 9999px;
+}
+
+.subtitle {
+  font-size: 2.3rem;
+  font-weight: 400;
+  line-height: 3rem;
+  color: #374151;
+  margin-bottom: 1rem;
+}
+
+.description {
+  font-size: 1.5rem;
+  font-weight: 100;
+  color: #919aac;
+  line-height: 1.6;
+  margin-bottom: 2.5rem;
+}
+
+.calculator_Btn {
+  background: linear-gradient(to right, #2563eb, #4f46e5);
+  color: white;
+  font-weight: 400;
+  font-size: 1.2rem;
+  padding: 1.2rem 3.5rem;
+  border-radius: 0.75rem;
+  box-shadow: 0 8px 28px rgba(79, 70, 229, 0.4);
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  text-decoration: none;
+  display: inline-block;
+  margin: 2rem 0 5rem;
+}
+
+.calculator_Btn:hover {
+  transform: translateY(-2px) scale(1.125);
+  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.25);
+}
+
+/* 기능 리스트 영역 */
+.featureList {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  width: 100%;
+  margin-top: 1rem;
+}
+
+@media (min-width: 768px) {
+  .featureList {
+    flex-direction: row;
+    justify-content: center;
+    flex-wrap: wrap;
+    gap: 2rem;
+  }
+}
+
+/* 기능 카드 아이템 */
+.featureItem {
+  flex: 1;
+  max-width: 320px;
+  margin: 0 auto;
+  background-color: white;
+  border-radius: 1.25rem;
+  padding: 1.75rem;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.07);
+  text-align: center;
+}
+
+.featureItem h2 {
+  font-size: 1.8rem;
+  font-weight: 500;
+  margin: 2rem 0;
+  color: #2c3644;
+}
+
+.featureItem p {
+  font-size: 1rem;
+  color: #6b7280;
+  line-height: 1.5;
+}
+
+.iconBox {
+  width: 63px;
+  height: 63px;
+  border-radius: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0 auto;
+}
+
+.iconBox svg {
+  width: 24px;
+  height: 24px;
+  color: inherit;
+}
+
+.blue {
+  background: #d9e5f6;
+}
+.green {
+  background: #cef2e6;
+}
+.purple {
+  background: #e9d9f8;
+}

--- a/src/app/page.module.css
+++ b/src/app/page.module.css
@@ -28,7 +28,7 @@
   font-weight: 400;
   line-height: 3rem;
   color: #374151;
-  margin-bottom: 1rem;
+  margin-bottom: 3rem;
 }
 
 .description {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,54 @@
+import Link from "next/link";
+import styles from "./page.module.css";
+import { Bot, Calculator, Lightbulb } from "lucide-react";
+
 export default function Home() {
   return (
-    <div>
-      <main>홈 컴포넌트</main>
+    <div className={styles.container}>
+      <section className={styles.headerSection}>
+        <h1>MiniTax</h1>
+
+        <div className={styles.divider} />
+
+        <p className={styles.subtitle}>
+          프리랜서도 쉽게 이해하는 <br /> 종합소득세 계산기
+        </p>
+        <p className={styles.description}>
+          복잡한 세법. 이제 고민하지 마세요. 연소득과 필요경비만 입력하면 AI가
+          세금을 <br /> 계산하고 쉽게 설명해드립니다.
+        </p>
+      </section>
+      <Link
+        href="/calculator"
+        className={styles.calculator_Btn}
+        aria-label="종합소득세 계산기 시작하기"
+      >
+        지금 계산 시작하기
+      </Link>
+
+      <section className={styles.featureList}>
+        <div className={styles.featureItem}>
+          <div className={`${styles.iconBox} ${styles.blue}`}>
+            <Calculator color="#6366f1" />
+          </div>
+          <h2>간단한 계산</h2>
+          <p>연소득과 필요경비만 입력하면 자동으로 세금을 계산해드립니다.</p>
+        </div>
+        <div className={styles.featureItem}>
+          <div className={`${styles.iconBox} ${styles.green}`}>
+            <Bot color="#10b981" />
+          </div>
+          <h2>AI 설명</h2>
+          <p>복잡한 세법을 AI가 쉽고 친근한 언어로 설명해드립니다.</p>
+        </div>
+        <div className={styles.featureItem}>
+          <div className={`${styles.iconBox} ${styles.purple}`}>
+            <Lightbulb color="#a855f7" />
+          </div>
+          <h2>절세 전략</h2>
+          <p>개인 상황에 맞는 절세 방법과 신고 유의사항을 제공합니다.</p>
+        </div>
+      </section>
     </div>
   );
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -25,7 +25,7 @@ const HeaderWrapper = styled.header`
   background-color: transparent;
 `;
 
-const StyledLink = styled.a`
+const StyledLink = styled(Link)`
   text-decoration: none;
 `;
 
@@ -51,11 +51,9 @@ const AnimatedText = styled.span`
 export default function Header() {
   return (
     <HeaderWrapper>
-      <Link href="/" passHref>
-        <StyledLink>
-          <AnimatedText>MiniTax</AnimatedText>
-        </StyledLink>
-      </Link>
+      <StyledLink href="/">
+        <AnimatedText>MiniTax</AnimatedText>
+      </StyledLink>
     </HeaderWrapper>
   );
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,7 +1,16 @@
 "use client";
 
 import Link from "next/link";
-import styled from "styled-components";
+import styled, { keyframes } from "styled-components";
+
+const gradientFlow = keyframes`
+  from {
+    background-position: 0% center;
+  }
+  to {
+    background-position: 200% center;
+  }
+`;
 
 const HeaderWrapper = styled.header`
   display: flex;
@@ -12,21 +21,37 @@ const HeaderWrapper = styled.header`
   border-bottom: 1px solid #eaeaea;
 `;
 
-const Logo = styled(Link)`
-  font-size: 1.2rem;
-  font-weight: 600;
-  color: #111;
+const StyledLink = styled.a`
   text-decoration: none;
+`;
+
+const AnimatedText = styled.span`
+  display: inline-block;
+  font-size: 1.5rem;
+  font-weight: 700;
+  background: linear-gradient(90deg, #2563eb, #7e22ce, #2563eb);
+  background-size: 200% auto;
+  background-clip: text;
+  -webkit-background-clip: text;
+  color: transparent;
+  -webkit-text-fill-color: transparent;
+  animation: ${gradientFlow} 4s linear infinite;
+
+  transition: transform 0.3s ease;
 
   &:hover {
-    color: #2563eb;
+    transform: scale(1.08);
   }
 `;
 
 export default function Header() {
   return (
     <HeaderWrapper>
-      <Logo href="/">MiniTax</Logo>
+      <Link href="/" passHref>
+        <StyledLink>
+          <AnimatedText>MiniTax</AnimatedText>
+        </StyledLink>
+      </Link>
     </HeaderWrapper>
   );
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -13,12 +13,16 @@ const gradientFlow = keyframes`
 `;
 
 const HeaderWrapper = styled.header`
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 999;
   display: flex;
   align-items: center;
   height: 60px;
   padding: 0 2rem;
-  background-color: #fff;
-  border-bottom: 1px solid #eaeaea;
+  background-color: transparent;
 `;
 
 const StyledLink = styled.a`


### PR DESCRIPTION
### 주요 변경 사항

1. 홈 페이지 UI 구현
- 홈페이지 헤더 섹션(타이틀, 설명, CTA 버튼) 구현
- 기능 카드 섹션(featureList) 3종 구성 (간단한 계산 / AI 설명 / 절세 전략)
- 아이콘 박스 스타일 추가 및 색상별 클래스 분리 (.blue, .green, .purple)
- 반응형 대응을 고려한 카드 레이아웃 및 텍스트 정렬 적용

2. 홈 페이지 부제목 하단 여백 조정
- .subtitle의 margin-bottom을 1rem → 3rem으로 수정

3. 헤더 스타일 개선
- 로고 텍스트에 linear-gradient와 keyframes 애니메이션 적용
- 호버 시 로고 텍스트가 부드럽게 확대되도록 transform scale 적용
- Header 컴포넌트를 position: fixed로 상단 고정 처리
- 배경색을 transparent로 설정하여 로고만 보이도록 구성
- .container에 padding-top 추가로 헤더 영역 가려짐 방지
- Next.js Link와 styled.a 조합 --> 중첩된 <Link> 구조 제거