### PR TITLE
feat: GPT 요약 중복 요청 캐싱 기능 구현

### DIFF
--- a/src/components/result/GptSummary.tsx
+++ b/src/components/result/GptSummary.tsx
@@ -92,7 +92,6 @@ export default function GptSummary({ result }: { result: TaxResult }) {
     }
 
     try {
-      dispatch({ type: "RESET_ALL" });
       dispatch({ type: "LOADING", payload: "default" });
 
       const res = await getGptSummary("default", result);
@@ -142,6 +141,13 @@ export default function GptSummary({ result }: { result: TaxResult }) {
     fetchSummary();
   }, [fetchSummary]);
 
+  const resetSummary = () => {
+    hasFetched.current = false;
+    cacheRef.current = {}; // 캐시 초기화
+    dispatch({ type: "RESET_ALL" }); // 상태 초기화
+    fetchSummary(); // 다시 fetch 트리거
+  };
+
   return (
     <section className={styles.container}>
       <div className={styles.header}>
@@ -157,7 +163,7 @@ export default function GptSummary({ result }: { result: TaxResult }) {
 
         <button
           className={styles.resetButton}
-          onClick={fetchSummary}
+          onClick={resetSummary}
           disabled={state.loading === "default"}
         >
           {state.loading === "default" ? (


### PR DESCRIPTION
### 주요 변경 사항
1. GPT 요약 캐싱 로직 구현 (cacheRef)
- 동일한 type ("default", "saving", "warning")에 대해 한 번 호출된 응답을 캐싱하여 재요청 방지
- 버튼 클릭 시에도 기존 캐시가 존재하면 API 요청 없이 바로 렌더링
	
2. 요약 요청 중복 호출 방지 (hasFetched)
- useEffect에서 fetchSummary()가 중복 호출되지 않도록 hasFetched 플래그로 제어
- 최초 렌더링 시 한 번만 GPT 요청 수행
	
3. resetSummary 호출 시 재요청 트리거 개선
- resetSummary() 호출 시 캐시와 플래그 초기화 후 fetchSummary() 재트리거
- 다시 설명 버튼 클릭 시 요약이 정상적으로 재요청되도록 개선