### PR TITLE
feat: 결과 페이지 스켈레톤 UI 구현 및 반응형 레이아웃 개선

### DIFF
--- a/src/app/result/page.module.css
+++ b/src/app/result/page.module.css
@@ -4,7 +4,6 @@
   padding: 2rem 1.2rem;
   max-width: 1000px;
   margin: 0 auto;
-  align-items: center;
 }
 
 .topBar {
@@ -37,18 +36,21 @@
   padding: 0.25rem 0.75rem;
   border-radius: 9999px;
   margin-bottom: 0.75rem;
+  align-self: center;
 }
 
 .title {
   font-size: 1.8rem;
   font-weight: 700;
   margin-bottom: 0.5rem;
+  text-align: center;
 }
 
 .sub {
   font-size: 1rem;
   color: #555;
   margin-bottom: 2rem;
+  text-align: center;
 }
 
 .errorCard {

--- a/src/app/result/page.tsx
+++ b/src/app/result/page.tsx
@@ -4,9 +4,20 @@ import { useTaxContext } from "@/context/TaxContext";
 import ResultCard from "@/components/result/ResultCard";
 import styles from "./page.module.css";
 import Link from "next/link";
+import { useEffect, useState } from "react";
+import SkeletonResult from "@/components/SkeletonResult";
 
 export default function Page() {
   const { result } = useTaxContext();
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const timeout = setTimeout(() => {
+      setIsLoading(false);
+    }, 1200);
+
+    return () => clearTimeout(timeout);
+  }, []);
 
   if (!result) {
     return (
@@ -35,7 +46,11 @@ export default function Page() {
       <p className={styles.sub}>
         {result.income.toLocaleString()}원 소득 기준으로 예상한 세금 결과입니다.
       </p>
-      <ResultCard result={result} />
+      {result && isLoading ? (
+        <SkeletonResult />
+      ) : (
+        <ResultCard result={result} />
+      )}
     </div>
   );
 }

--- a/src/components/SkeletonResult.module.css
+++ b/src/components/SkeletonResult.module.css
@@ -1,0 +1,88 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  margin-top: 3rem;
+}
+
+.flexRow {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.cardSkeleton,
+.detailSkeleton,
+.gptCard {
+  background: linear-gradient(90deg, #d1d1d1 0%, #e0e0e0 50%, #d1d1d1 100%);
+  background-size: 200% 100%;
+  animation: shimmer 1.4s ease-in-out infinite;
+  border-radius: 8px;
+}
+
+/* 개별 사이즈 및 레이아웃 */
+.cardSkeleton {
+  flex: 1;
+  height: 100px;
+  min-width: 180px;
+  border-radius: 12px;
+}
+
+.detailSkeleton {
+  flex: 1 1 300px; /* grow, shrink, basis */
+  height: 220px;
+  border-radius: 16px;
+}
+
+.gptCard {
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  width: 100%;
+  border-radius: 20px;
+}
+
+.gptLine,
+.gptHeaderSkeleton,
+.gptButton {
+  width: 100%;
+  height: 20px;
+  border-radius: 6px;
+  background: linear-gradient(90deg, #bbbbbb 0%, #dddddd 50%, #bbbbbb 100%);
+  background-size: 200% 100%;
+  animation: shimmer 1.4s ease-in-out infinite;
+}
+
+.gptHeaderSkeleton {
+  width: 60%;
+  height: 24px;
+}
+
+.gptButton {
+  flex: 1;
+  height: 40px;
+}
+
+.buttonRow {
+  display: flex;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+/* 애니메이션 */
+@keyframes shimmer {
+  0% {
+    background-position: -200% 0;
+  }
+  100% {
+    background-position: 200% 0;
+  }
+}
+
+/* 반응형 */
+@media (max-width: 768px) {
+  .cardSkeleton {
+    display: none;
+  }
+}

--- a/src/components/SkeletonResult.tsx
+++ b/src/components/SkeletonResult.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import styles from "./SkeletonResult.module.css";
+
+export default function SkeletonResult() {
+  return (
+    <section className={styles.container}>
+      {/* SummaryCard 영역 */}
+      <div className={styles.flexRow}>
+        <div className={styles.cardSkeleton} />
+        <div className={styles.cardSkeleton} />
+        <div className={styles.cardSkeleton} />
+      </div>
+
+      {/* 상세 카드 영역 */}
+      <div className={styles.flexRow}>
+        <div className={styles.detailSkeleton} />
+        <div className={styles.detailSkeleton} />
+      </div>
+
+      {/* GPT 요약 카드 영역 */}
+      <div className={styles.gptCard}>
+        <div className={styles.gptHeaderSkeleton} />
+        <div className={styles.gptLine} />
+        <div className={styles.gptLine} />
+        <div className={styles.gptLine} />
+        <div className={styles.buttonRow}>
+          <div className={styles.gptButton} />
+          <div className={styles.gptButton} />
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
### 주요 변경 사항
1. 결과 페이지 로딩 시 Skeleton UI 적용
- 카드 3종 (요약, 소득 내역, 세액 계산) + GPT 요약 카드에 shimmer 애니메이션 적용
- SkeletonResult 컴포넌트 분리로 로딩 상태 처리 구조화

2. 반응형 레이아웃 대응
- 모바일 화면(max-width: 768px)에서 불필요한 스켈레톤 요소 숨김
- 결과 페이지 container 속성 조정(text-align: center 제거)으로 좁은 화면에서도 레이아웃 깨짐 현상 해결
- 결과 페이지 container 내부 자식 요소에 text-align: center, align-self 등 적용으로 콘텐츠 중앙 정렬 처리