### PR TITLE
fix: 결과 페이지 초기 렌더 시 일시적 0원 출력 문제 해결

### DIFF
--- a/src/components/result/ResultClient.tsx
+++ b/src/components/result/ResultClient.tsx
@@ -26,7 +26,12 @@ export default function ResultClient() {
     return () => clearTimeout(timeout);
   }, []);
 
-  // 예외 처리: 계산 결과가 없을 경우 에러 메시지 표시
+  // 1. 로딩 중인데 result도 없으면 Skeleton 표시
+  if (!result && isLoading) {
+    return <SkeletonResult />;
+  }
+
+  // 2. 로딩 끝났는데 result가 없다면 에러 카드
   if (!result) {
     return (
       <div className={styles.errorCard} role="alert" aria-live="assertive">
@@ -71,11 +76,7 @@ export default function ResultClient() {
       </p>
 
       {/* 조건부 렌더링: 로딩 중이면 Skeleton, 완료되면 ResultCard */}
-      {result && isLoading ? (
-        <SkeletonResult />
-      ) : (
-        <ResultCard result={result} />
-      )}
+      {isLoading ? <SkeletonResult /> : <ResultCard result={result} />}
     </div>
   );
 }


### PR DESCRIPTION
- result 값이 아직 반영되지 않은 상태에서 페이지가 렌더되는 문제 대응
- 로딩 중 && result 없음 → SkeletonResult 표시
- 로딩 끝 && result 없음 → 에러 카드 표시