### PR TITLE
fix: 모바일 UI 깨짐 및 가독성 문제 개선을 위한 반응형 스타일 세분화

### DIFF
--- a/src/app/about/page.module.css
+++ b/src/app/about/page.module.css
@@ -307,3 +307,117 @@
     height: 20px;
   }
 }
+
+/* 480px 이하 - 일반 소형 스마트폰 */
+@media (max-width: 480px) {
+  .container {
+    padding: 1rem 0.75rem;
+  }
+
+  .title h1 {
+    font-size: 2rem;
+    margin: 0.5rem 0;
+    padding: 0.5rem 0;
+  }
+
+  .card {
+    padding: 0.75rem;
+  }
+
+  .card h3 {
+    font-size: 0.95rem;
+  }
+
+  .card p {
+    font-size: 0.85rem;
+  }
+
+  .promiseSection h2 {
+    font-size: 1.25rem;
+  }
+
+  .promiseSection p {
+    font-size: 0.95rem;
+  }
+
+  .policy_Btn {
+    font-size: 0.875rem;
+    padding: 0.5rem 1rem;
+  }
+
+  .iconBox {
+    width: 44px;
+    height: 44px;
+  }
+
+  .iconBox svg {
+    width: 18px;
+    height: 18px;
+  }
+}
+
+/* 375px 이하 - iPhone SE, 갤럭시 Z Flip 등 */
+@media (max-width: 375px) {
+  .title h1 {
+    font-size: 1.75rem;
+  }
+
+  .card h3 {
+    font-size: 0.9rem;
+  }
+
+  .card p {
+    font-size: 0.8rem;
+  }
+
+  .featureItem h3 {
+    font-size: 0.95rem;
+  }
+
+  .featureItem p {
+    font-size: 0.8rem;
+  }
+
+  .promiseSection p {
+    font-size: 0.9rem;
+    line-height: 1.6;
+  }
+}
+
+/* 320px 이하a */
+@media (max-width: 340px) {
+  .container {
+    padding: 0.75rem;
+  }
+
+  .title h1 {
+    font-size: 1.5rem;
+  }
+
+  .card {
+    padding: 0.5rem;
+  }
+
+  .card p {
+    font-size: 0.75rem;
+  }
+
+  .promiseSection p {
+    font-size: 0.85rem;
+  }
+
+  .policy_Btn {
+    font-size: 0.85rem;
+    padding: 0.5rem 0.75rem;
+  }
+
+  .iconBox {
+    width: 40px;
+    height: 40px;
+  }
+
+  .iconBox svg {
+    width: 16px;
+    height: 16px;
+  }
+}

--- a/src/app/calculator/page.module.css
+++ b/src/app/calculator/page.module.css
@@ -120,3 +120,90 @@
     font-size: 0.85rem;
   }
 }
+
+/* 480px 이하 */
+@media (max-width: 480px) {
+  .container {
+    margin: 0 0.75rem;
+  }
+
+  .subTitle {
+    font-size: 1.1rem;
+  }
+
+  .title {
+    font-size: 1.75rem;
+    line-height: 1.3;
+  }
+
+  .description {
+    font-size: 0.85rem;
+    line-height: 1.5;
+  }
+
+  .badge {
+    font-size: 0.7rem;
+    padding: 0.25rem 0.7rem;
+    gap: 0.2rem;
+  }
+
+  .featureItem {
+    font-size: 0.8rem;
+  }
+}
+
+/* 375px 이하 */
+@media (max-width: 375px) {
+  .container {
+    margin: 0 0.5rem;
+  }
+
+  .title {
+    font-size: 1.55rem;
+    line-height: 1.3;
+  }
+
+  .description {
+    font-size: 0.8rem;
+  }
+
+  .featureItem {
+    font-size: 0.75rem;
+  }
+
+  .badge {
+    font-size: 0.68rem;
+    padding: 0.25rem 0.6rem;
+  }
+}
+
+/* 340px */
+@media (max-width: 340px) {
+  .container {
+    margin: 0 0.25rem;
+  }
+
+  .subTitle {
+    font-size: 1rem;
+  }
+
+  .title {
+    font-size: 1.4rem;
+    margin-top: 0.2rem;
+    margin-bottom: 0.2rem;
+  }
+
+  .description {
+    font-size: 0.75rem;
+    line-height: 1.4;
+  }
+
+  .featureItem {
+    font-size: 0.7rem;
+  }
+
+  .badge {
+    font-size: 0.65rem;
+    padding: 0.2rem 0.5rem;
+  }
+}

--- a/src/app/page.module.css
+++ b/src/app/page.module.css
@@ -177,3 +177,106 @@
     gap: 2rem;
   }
 }
+
+/* 375px 이하 */
+@media (max-width: 375px) {
+  .headerSection h1 {
+    font-size: 2.3rem;
+    margin: 0.5rem 0;
+    padding-bottom: 1rem;
+  }
+
+  .divider {
+    width: 4rem;
+    height: 3px;
+    margin: 0 auto 1rem;
+  }
+
+  .subtitle {
+    font-size: 1.3rem;
+    margin: 1.75rem;
+    line-height: 2rem;
+  }
+
+  .description {
+    font-size: 0.9rem;
+    line-height: 1.4;
+    margin-bottom: 2rem;
+    margin-bottom: 1.2rem;
+  }
+
+  .calculator_Btn {
+    font-size: 0.95rem;
+    padding: 0.8rem 2rem;
+    margin-bottom: 4rem;
+  }
+
+  .featureList {
+    gap: 0.5rem;
+    margin-top: 0.5rem;
+  }
+
+  .featureItem {
+    padding: 1rem;
+  }
+
+  .featureItem h2 {
+    font-size: 1.2rem;
+    margin: 1rem 0;
+  }
+
+  .featureItem p {
+    font-size: 0.9rem;
+  }
+
+  .iconBox {
+    width: 42px;
+    height: 42px;
+  }
+
+  .iconBox svg {
+    width: 18px;
+    height: 18px;
+  }
+}
+
+/* 340px 이하 */
+@media (max-width: 340px) {
+  .headerSection h1 {
+    font-size: 2rem;
+  }
+
+  .subtitle {
+    font-size: 1.15rem;
+    line-height: 1.8rem;
+  }
+
+  .description {
+    font-size: 0.85rem;
+    line-height: 1.3;
+    margin-bottom: 1.5rem;
+  }
+
+  .calculator_Btn {
+    font-size: 0.85rem;
+    padding: 0.75rem 1.5rem;
+  }
+
+  .featureItem h2 {
+    font-size: 1.1rem;
+  }
+
+  .featureItem p {
+    font-size: 0.85rem;
+  }
+
+  .iconBox {
+    width: 38px;
+    height: 38px;
+  }
+
+  .iconBox svg {
+    width: 16px;
+    height: 16px;
+  }
+}

--- a/src/app/policy/page.module.css
+++ b/src/app/policy/page.module.css
@@ -330,3 +330,144 @@
     padding: 0.5rem 1rem;
   }
 }
+
+/* 480px 이하 */
+@media (max-width: 480px) {
+  .container {
+    padding: 1rem 0.75rem;
+  }
+
+  .card h2 {
+    font-size: 0.95rem;
+  }
+
+  .card p {
+    font-size: 0.8rem;
+  }
+
+  .iconBox {
+    width: 36px;
+    height: 36px;
+  }
+
+  .iconBox svg {
+    width: 1rem;
+    height: 1rem;
+  }
+
+  .textBox > div:last-child {
+    font-size: 0.8rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .title h1 {
+    font-size: 1.5rem;
+  }
+
+  .about_Btn {
+    font-size: 0.85rem;
+    padding: 0.5rem 0.75rem;
+  }
+
+  .agreementSection h2 {
+    font-size: 1.3rem;
+  }
+
+  .agreementSection p {
+    font-size: 0.9rem;
+  }
+
+  .numberList li {
+    font-size: 0.9rem;
+  }
+
+  .numberList span {
+    font-size: 0.95rem;
+    width: 1.2rem;
+  }
+}
+
+/* 375px 이하 */
+@media (max-width: 375px) {
+  .card {
+    padding: 0.5rem;
+  }
+
+  .card p {
+    font-size: 0.75rem;
+  }
+
+  .card h2 {
+    font-size: 0.9rem;
+  }
+
+  .textBox > div:last-child {
+    font-size: 0.75rem;
+    padding: 0.5rem 0.75rem;
+  }
+
+  .iconBox {
+    width: 32px;
+    height: 32px;
+  }
+
+  .iconBox svg {
+    width: 0.95rem;
+    height: 0.95rem;
+  }
+
+  .title h1 {
+    font-size: 1.35rem;
+  }
+
+  .agreementSection h2 {
+    font-size: 1.2rem;
+  }
+
+  .agreementSection p {
+    font-size: 0.85rem;
+  }
+
+  .about_Btn {
+    font-size: 0.8rem;
+    padding: 0.4rem 0.75rem;
+  }
+}
+
+/* 340px 이하 */
+@media (max-width: 340px) {
+  .container {
+    padding: 0.5rem;
+  }
+
+  .card p,
+  .textBox > div:last-child {
+    font-size: 0.7rem;
+  }
+
+  .card h2 {
+    font-size: 0.85rem;
+  }
+
+  .iconBox {
+    width: 28px;
+    height: 28px;
+  }
+
+  .iconBox svg {
+    width: 0.85rem;
+    height: 0.85rem;
+  }
+
+  .title h1 {
+    font-size: 1.25rem;
+  }
+
+  .agreementSection p {
+    font-size: 0.8rem;
+  }
+
+  .about_Btn {
+    font-size: 0.75rem;
+  }
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { useEffect, useState } from "react";
 import styled, { keyframes } from "styled-components";
 
 /**
@@ -20,8 +21,12 @@ const gradientFlow = keyframes`
   }
 `;
 
-const HeaderWrapper = styled.header`
-  // 상단 고정 헤더 스타일
+const HeaderWrapper = styled.header.attrs<{ $scrolled: boolean }>((props) => ({
+  style: {
+    backgroundColor: props.$scrolled ? "#ffffff" : "transparent",
+    boxShadow: props.$scrolled ? "0 2px 8px rgba(0, 0, 0, 0.06)" : "none",
+  },
+}))`
   position: fixed;
   top: 0;
   left: 0;
@@ -31,7 +36,7 @@ const HeaderWrapper = styled.header`
   align-items: center;
   height: 60px;
   padding: 0 2rem;
-  background-color: transparent;
+  transition: background-color 0.3s ease, box-shadow 0.3s ease;
 
   @media (max-width: 768px) {
     padding: 0 1rem;
@@ -75,8 +80,21 @@ const AnimatedText = styled.span`
 `;
 
 export default function Header() {
+  const [isScrolled, setIsScrolled] = useState(false);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      const y = window.scrollY;
+      setIsScrolled(y > 10);
+    };
+
+    window.addEventListener("scroll", handleScroll);
+
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, []);
+
   return (
-    <HeaderWrapper>
+    <HeaderWrapper $scrolled={isScrolled}>
       <StyledLink href="/">
         <AnimatedText>MiniTax</AnimatedText>
       </StyledLink>

--- a/src/components/calculator/CalculatorForm.module.css
+++ b/src/components/calculator/CalculatorForm.module.css
@@ -304,8 +304,8 @@
   }
 }
 
-/* 초소형 기기 대응 – 360px 이하 */
-@media (max-width: 360px) {
+/* 375px 이하 */
+@media (max-width: 375px) {
   .formTitle {
     font-size: 1rem;
   }
@@ -321,11 +321,37 @@
   }
 
   .noticeBox p {
-    font-size: 0.7rem;
-    line-height: 1.45;
+    font-size: 0.75rem;
+    line-height: 1.5;
   }
 
   .noticeBox h3 {
-    font-size: 0.9rem;
+    font-size: 0.95rem;
+  }
+}
+
+/* 340px 이하 */
+@media (max-width: 340px) {
+  .formTitle {
+    font-size: 0.95rem;
+  }
+
+  .inputWrapper input {
+    font-size: 0.95rem;
+    padding: 0.6rem 1.6rem 0.6rem 0.65rem;
+  }
+
+  .submit {
+    font-size: 0.8rem;
+    padding: 0.65rem;
+  }
+
+  .noticeBox p {
+    font-size: 0.7rem;
+    line-height: 1.4;
+  }
+
+  .noticeBox h3 {
+    font-size: 0.85rem;
   }
 }

--- a/src/components/result/GptSection.module.css
+++ b/src/components/result/GptSection.module.css
@@ -104,3 +104,48 @@
     text-align: center;
   }
 }
+
+/* 275px 이하 */
+@media (max-width: 375px) {
+  .gpt_wrapper {
+    margin: 1rem;
+    padding: 1rem;
+    border-radius: 12px;
+  }
+
+  .title {
+    font-size: 0.95rem;
+    gap: 0.3rem;
+  }
+
+  .list {
+    font-size: 0.85rem;
+    gap: 0.3rem;
+  }
+
+  .loading {
+    font-size: 0.85rem;
+  }
+}
+
+/* 340px 이하 */
+@media (max-width: 340px) {
+  .gpt_wrapper {
+    margin: 0.75rem;
+    padding: 0.75rem;
+    border-radius: 10px;
+  }
+
+  .title {
+    font-size: 0.9rem;
+  }
+
+  .list {
+    font-size: 0.8rem;
+  }
+
+  .loading {
+    font-size: 0.8rem;
+    gap: 0.25rem;
+  }
+}

--- a/src/components/result/GptSummary.module.css
+++ b/src/components/result/GptSummary.module.css
@@ -211,3 +211,88 @@
     padding: 0.6rem;
   }
 }
+
+@media (max-width: 375px) {
+  .header {
+    padding: 1.25rem;
+    gap: 0.75rem;
+  }
+
+  .iconBox {
+    width: 40px;
+    height: 40px;
+    font-size: 18px;
+  }
+
+  .textGroup h2 {
+    font-size: 1rem;
+  }
+
+  .textGroup p {
+    font-size: 0.7rem;
+  }
+
+  .resetButton {
+    font-size: 0.75rem;
+    padding: 0.5rem 0.75rem;
+  }
+
+  .label {
+    font-size: 0.75rem;
+    padding: 8px;
+    margin-left: 0.75rem;
+    margin-right: 0.75rem;
+  }
+
+  .buttonWrapper {
+    padding: 0 0.75rem;
+    gap: 0.6rem;
+  }
+
+  .labelButton {
+    font-size: 0.75rem;
+    padding: 0.6rem;
+  }
+}
+
+@media (max-width: 340px) {
+  .header {
+    padding: 1rem;
+    gap: 0.5rem;
+  }
+
+  .iconBox {
+    width: 36px;
+    height: 36px;
+    font-size: 16px;
+  }
+
+  .textGroup h2 {
+    font-size: 0.95rem;
+  }
+
+  .textGroup p {
+    font-size: 0.68rem;
+  }
+
+  .resetButton {
+    font-size: 0.7rem;
+    padding: 0.4rem 0.6rem;
+  }
+
+  .label {
+    font-size: 0.7rem;
+    padding: 6px;
+    margin: 0 0.5rem;
+  }
+
+  .buttonWrapper {
+    padding: 0 0.5rem;
+    gap: 0.5rem;
+  }
+
+  .labelButton {
+    font-size: 0.7rem;
+    padding: 0.5rem;
+  }
+}

--- a/src/components/result/IncomeBreakdownCard.module.css
+++ b/src/components/result/IncomeBreakdownCard.module.css
@@ -120,10 +120,12 @@
 @media (max-width: 420px) {
   .card {
     padding: 1.25rem;
+    border-radius: 1rem;
   }
 
   .list li {
     margin-bottom: 1.25rem;
+    font-size: 0.9rem;
   }
 
   .footer {
@@ -141,5 +143,62 @@
 
   .subtitle {
     font-size: 0.75rem;
+  }
+}
+
+@media (max-width: 375px) {
+  .card {
+    padding: 1rem;
+  }
+
+  .iconBox {
+    width: 34px;
+    height: 34px;
+  }
+
+  .title {
+    font-size: 0.9rem;
+  }
+
+  .subtitle {
+    font-size: 0.7rem;
+  }
+
+  .list li {
+    font-size: 0.85rem;
+    margin-bottom: 1rem;
+  }
+
+  .footer {
+    font-size: 0.95rem;
+  }
+}
+
+@media (max-width: 340px) {
+  .card {
+    padding: 0.85rem;
+  }
+
+  .iconBox {
+    width: 30px;
+    height: 30px;
+  }
+
+  .title {
+    font-size: 0.85rem;
+  }
+
+  .subtitle {
+    font-size: 0.68rem;
+  }
+
+  .list li {
+    font-size: 0.8rem;
+    margin-bottom: 0.75rem;
+  }
+
+  .footer {
+    font-size: 0.85rem;
+    padding: 0.75rem;
   }
 }

--- a/src/components/result/ResultCard.module.css
+++ b/src/components/result/ResultCard.module.css
@@ -35,3 +35,26 @@
     flex-direction: column;
   }
 }
+
+@media (max-width: 768px) {
+  .container {
+    max-width: 100%;
+    padding: 0 0.75rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .container {
+    max-width: 100%;
+    padding: 0 0.25rem;
+    gap: 0.5rem;
+  }
+}
+
+@media (max-width: 340px) {
+  .container {
+    max-width: 100%;
+    padding: 0;
+    gap: 0.3rem;
+  }
+}

--- a/src/components/result/ResultClient.module.css
+++ b/src/components/result/ResultClient.module.css
@@ -4,7 +4,6 @@
   padding: 2rem 1.2rem;
   max-width: 1000px;
   margin: 0 auto;
-  border: 1px solid red;
 }
 
 /* 상단 바: "다시 계산하기" 버튼이 우측에 배치됨 */

--- a/src/components/result/ResultClient.module.css
+++ b/src/components/result/ResultClient.module.css
@@ -4,6 +4,7 @@
   padding: 2rem 1.2rem;
   max-width: 1000px;
   margin: 0 auto;
+  border: 1px solid red;
 }
 
 /* 상단 바: "다시 계산하기" 버튼이 우측에 배치됨 */
@@ -94,18 +95,10 @@
 }
 
 .backButton:hover {
-  background-color: #334155; /* slate-800 */
+  background-color: #334155;
 }
 
 /* 반응형 스타일 - 모바일 대응 */
-
-@media (max-width: 480px) {
-  .recalculateButton {
-    font-size: 0.85rem;
-    padding: 0.5rem 1rem;
-  }
-}
-
 @media (max-width: 768px) {
   .container {
     padding: 2rem 1rem;
@@ -146,5 +139,114 @@
   .backButton {
     font-size: 0.9rem;
     padding: 0.65rem 1.25rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .container {
+    padding: 1.5rem 0.8rem;
+  }
+
+  .title {
+    font-size: 1.3rem;
+    margin-bottom: 0.4rem;
+  }
+
+  .sub {
+    font-size: 0.85rem;
+    margin-bottom: 1.5rem;
+  }
+
+  .badge {
+    font-size: 0.75rem;
+    padding: 0.2rem 0.5rem;
+    margin-bottom: 0.6rem;
+  }
+
+  .recalculateButton {
+    font-size: 0.8rem;
+    padding: 0.5rem 0.8rem;
+    border-radius: 0.6rem;
+  }
+
+  .errorCard {
+    padding: 1.2rem;
+    margin: 2.5rem auto;
+  }
+
+  .errorCard h2 {
+    font-size: 1.2rem;
+  }
+
+  .errorCard p {
+    font-size: 0.9rem;
+    margin-bottom: 1.5rem;
+  }
+
+  .backButton {
+    font-size: 0.85rem;
+    padding: 0.6rem 1rem;
+  }
+}
+
+@media (max-width: 375px) {
+  .container {
+    padding: 1.2rem 0.6rem;
+  }
+
+  .title {
+    font-size: 1.2rem;
+  }
+
+  .sub {
+    font-size: 0.8rem;
+    margin-bottom: 1.2rem;
+  }
+
+  .recalculateButton {
+    font-size: 0.75rem;
+    padding: 0.45rem 0.8rem;
+  }
+
+  .badge {
+    font-size: 0.7rem;
+  }
+
+  .errorCard h2 {
+    font-size: 1.1rem;
+  }
+
+  .errorCard p {
+    font-size: 0.85rem;
+  }
+
+  .backButton {
+    font-size: 0.8rem;
+    padding: 0.5rem 0.9rem;
+  }
+}
+
+@media (max-width: 340px) {
+  .container {
+    padding: 1rem 0.5rem;
+  }
+
+  .title {
+    font-size: 1.05rem;
+  }
+
+  .sub {
+    font-size: 0.75rem;
+    margin-bottom: 1rem;
+  }
+
+  .recalculateButton {
+    font-size: 0.7rem;
+    padding: 0.4rem 0.7rem;
+  }
+
+  .backButton {
+    font-size: 0.75rem;
+    padding: 0.45rem 0.8rem;
   }
 }

--- a/src/components/result/TaxCalculationCard.module.css
+++ b/src/components/result/TaxCalculationCard.module.css
@@ -186,3 +186,87 @@
     border-radius: 0.6rem;
   }
 }
+
+@media (max-width: 375px) {
+  .card {
+    padding: 1rem;
+  }
+
+  .iconBox {
+    width: 34px;
+    height: 34px;
+  }
+
+  .title {
+    font-size: 0.9rem;
+  }
+
+  .sub {
+    font-size: 0.7rem;
+  }
+
+  .value {
+    font-size: 0.9rem;
+  }
+
+  .badgeBlue,
+  .badgeGreen {
+    font-size: 0.65rem;
+    padding: 0.1rem 0.35rem;
+  }
+
+  .list li {
+    font-size: 0.85rem;
+    margin-bottom: 1rem;
+  }
+
+  .totalLabel {
+    font-size: 0.85rem;
+  }
+
+  .totalAmount {
+    font-size: 0.95rem;
+  }
+}
+
+@media (max-width: 340px) {
+  .card {
+    padding: 0.85rem;
+  }
+
+  .iconBox {
+    width: 30px;
+    height: 30px;
+  }
+
+  .title {
+    font-size: 0.85rem;
+  }
+
+  .sub {
+    font-size: 0.68rem;
+  }
+
+  .value {
+    font-size: 0.85rem;
+  }
+
+  .badgeBlue,
+  .badgeGreen {
+    font-size: 0.6rem;
+    padding: 0.1rem 0.3rem;
+  }
+
+  .list li {
+    font-size: 0.8rem;
+    margin-bottom: 0.75rem;
+  }
+
+  .totalLabel {
+    font-size: 0.8rem;
+  }
+
+  .totalAmount {
+    font-size: 0.9rem;
+  }
+}


### PR DESCRIPTION
### 주요 변경 사항
1. /about, /policy, /calculator, /result, / 홈 페이지
→ 초소형 디바이스 대응을 위한 반응형 스타일 세분화
  - 뷰포트 기준 480px / 375px / 340px 구간별로 margin, font-size, padding 등 조정
  - /calculator: 모바일에서 입력폼 여백 축소 및 레이아웃 정렬 최적화
  - /result: 세금 카드 간 여백 및 정렬 개선
  - /about, /policy: 텍스트 가독성 개선 및 영역별 여백 조정
  - 홈: 기능 카드 영역 여백 및 flex-wrap 대응
 2. 헤더 스크롤 반응 기능 추가
  - window.scrollY 값이 10px 이상일 때 헤더에 흰 배경 및 그림자 적용
  - styled-components.attrs()를 활용하여 $scrolled prop 기반 동적 스타일 처리
  - 사용자가 스크롤 시 자연스럽게 UI 상태 변화 제공
3. 레이아웃 확인용 border 제거
  - .container에 임시로 삽입했던 border 테스트 코드 제거
